### PR TITLE
added web support on core

### DIFF
--- a/lib/src/entity_template_filler.dart
+++ b/lib/src/entity_template_filler.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:dto_to_entity_model_core/src/template/entity_template.dart';
+
 class EntityTemplateFiller {
   final String entityName;
   final List<String> fields;
@@ -18,13 +20,13 @@ class EntityTemplateFiller {
   });
 
   Future<File> generateFile(String saveLocation) async {
-    final _generatedEntityStr = await generateEntity();
+    final _generatedEntityStr = generateEntity();
 
     return await File(saveLocation).writeAsString(_generatedEntityStr);
   }
 
-  Future<String> generateEntity() async {
-    var templateStr = await File('template/entity_template').readAsString();
+  String generateEntity() {
+    var templateStr = entityTemplate;
     templateStr = templateStr.replaceAll('{{ entityName }}', entityName);
     templateStr = templateStr.replaceAll('{{ fields }}', fields.join('\n'));
     templateStr = templateStr.replaceAll(

--- a/lib/src/model_template_filler.dart
+++ b/lib/src/model_template_filler.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:dto_to_entity_model_core/src/template/model_template.dart';
+
 class ModelTemplateFiller {
   final String entityName;
   final String entityFileName;
@@ -22,13 +24,13 @@ class ModelTemplateFiller {
   });
 
   Future<File> generateFile(String saveLocation) async {
-    final _generatedModelStr = await generateModel();
+    final _generatedModelStr = generateModel();
 
     return await File(saveLocation).writeAsString(_generatedModelStr);
   }
 
-  Future<String> generateModel() async {
-    var templateStr = await File('template/model_template').readAsString();
+  String generateModel() {
+    var templateStr = modelTemplate;
 
     templateStr = templateStr.replaceAll('{{ modelName }}', modelName);
     templateStr = templateStr.replaceAll('{{ entityName }}', entityName);

--- a/lib/src/template/entity_template.dart
+++ b/lib/src/template/entity_template.dart
@@ -1,3 +1,4 @@
+const entityTemplate = '''
 import 'package:tatsam_app_experimental/features/view-all-content/domain/entities/entity.dart';
 
 class {{ entityName }} extends Entity {
@@ -19,3 +20,4 @@ class {{ entityName }} extends Entity {
   @override
   int get hashCode => {{ hashCode }};
 }
+''';

--- a/lib/src/template/model_template.dart
+++ b/lib/src/template/model_template.dart
@@ -1,3 +1,4 @@
+const modelTemplate = '''
 import 'package:tatsam_app_experimental/core/logger/logger.dart';
 import 'package:tatsam_app_experimental/core/utils/helper_functions/check_if_null.dart';
 import 'package:tatsam_app_experimental/features/view-all-content/data/models/data-model.dart';
@@ -24,3 +25,4 @@ class {{ modelName }} extends DataModel<{{ entityName }}> {
 
   {{ generatedFromJson }}
 }
+''';


### PR DESCRIPTION
- apparently dart:io wasn's supported on web and we were using it to read our entity and model templates, So replacing it with docStrings